### PR TITLE
Fix path transform and deprecation warnings

### DIFF
--- a/laser.py
+++ b/laser.py
@@ -26,6 +26,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 import inkex
+from inkex.transforms import Transform
+from inkex.paths import Path
 import simpletransform
 
 import os
@@ -935,7 +937,7 @@ class LaserGcode(inkex.Effect):
     def apply_transforms(self, g, csp):
         trans = self.get_transforms(g)
         if trans != []:
-            simpletransform.applyTransformToPath(trans, csp)
+            csp = Path(csp).transform(Transform(trans)).to_superpath()
         return csp
 
 

--- a/laser.py
+++ b/laser.py
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 import inkex
 from inkex.transforms import Transform
 from inkex.paths import Path
-import simpletransform
 
 import os
 import math
@@ -927,8 +926,8 @@ class LaserGcode(inkex.Effect):
         while (g != root):
             if 'transform' in list(g.keys()):
                 t = g.get('transform')
-                t = simpletransform.parseTransform(t)
-                trans = simpletransform.composeTransform(t, trans) if trans != [] else t
+                t = [list(row) for row in Transform(t).matrix] 
+                trans = [list(row) for row in (Transform(t) * Transform(trans)).matrix] if trans != [] else t
                 print_(trans)
             g = g.getparent()
         return trans


### PR DESCRIPTION
I was experiencing the same issues @JuPrgn mentioned on #4.

Think the issue is that when Inkscape deprecated `simpletransform`, the replacement functions don't behave exactly the same way.

https://inkscape.gitlab.io/inkscape/doxygen-extensions/simpletransform_8py_source.html#l00066

For `applyTransformToPath`, the path is not transformed in place, but returned. Also, the return format (provided by `.to_arrays()`) is not the one this plugin is expecting (that seems to be `.to_superpath()`. Tought about using [`Path.transform` with `inPlace=true`](https://inkscape.gitlab.io/inkscape/doxygen-extensions/paths_8py_source.html#l01125), but would have to call `to_superpath()` anyways.

I also updated the other calls to `simpletransform` functions in order to remove the deprecation warnings.