### PR TITLE
feat: add start and end G-code command options

### DIFF
--- a/laser.inx
+++ b/laser.inx
@@ -5,6 +5,8 @@
 	<dependency type="executable" location="extensions">laser.py</dependency>
 	<dependency type="executable" location="extensions">inkex.py</dependency>
 
+	<param name="start-gcode" type="string" _gui-text="Start G-code:"></param>
+	<param name="end-gcode" type="string" _gui-text="End G-code:"></param>	
 	<param name="laser-command" type="string" _gui-text="Laser ON Command:">M03</param>
 	<param name="laser-off-command" type="string" _gui-text="Laser OFF Command:">M05</param>
 	<param name="travel-speed" type="int" min="0" max="15000" _gui-text="Travel Speed (mm/min or in/min):">3000</param>

--- a/laser.py
+++ b/laser.py
@@ -571,9 +571,16 @@ class LaserGcode(inkex.Effect):
         for x in range(1, self.options.passes):
             gcode += "G91\nG1 Z-" + self.options.pass_depth + "\nG90\n" + gcode_pass
         f = open(self.options.directory + self.options.file, "w")
+        
+        if self.options.start_gcode != "":
+            self.options.start_gcode = self.options.start_gcode + "\n"
+        if self.options.end_gcode != "":
+            self.options.end_gcode = self.options.end_gcode + "\n"
+			
         f.write(
             self.options.laser_off_command + " S0" + "\n" + self.header +
-            "G1 F" + self.options.travel_speed + "\n" + gcode + self.footer)
+            "G1 F" + self.options.travel_speed + "\n" + self.options.start_gcode 
+            + gcode + self.options.end_gcode + self.footer)
         f.close()
 
     def add_arguments_old(self):
@@ -612,6 +619,12 @@ class LaserGcode(inkex.Effect):
             {"name": "--add-numeric-suffix-to-filename", "type": inkex.Boolean,
              "dest": "add_numeric_suffix_to_filename", "default": False,
              "help": "Add numeric suffix to file name"},
+
+            {"name": "--start-gcode", "type": str, "dest": "start_gcode",
+             "default": "", "help": "Start G-code command"},
+
+            {"name": "--end-gcode", "type": str, "dest": "end_gcode",
+             "default": "", "help": "End G-code command"},
 
             {"name": "--laser-command", "type": str, "dest": "laser_command",
              "default": "M03", "help": "Laser gcode command"},


### PR DESCRIPTION
Usefull to turn on/off relay/power supply only once.
I would prefer to use multi line text fields on the dialog but this is a new feature from Inkscape 1.0 and would not be compatible with previous versions.