### PR TITLE
Sort paths by hierarchy, adaptation for python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,0 @@
-/.idea/
-/venv/
-/venv27/
-/old/
-/tools/
-/cycles/
-remove_unused.py
-copy.bat
-laser27.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # J Tech Photonics Laser Tool
 
-This is the new official home for the JTP laser cutting Inskape extension.
+This is the new official home for the JTP laser cutting Inkscape extension.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ More documentation coming soon. In the meantime you can refer to [JTP's official
 
 ## For developers
 
-Pull requests are welcome both for bug fixes and new features. Just make sure to test your code on both Python >=2.6 and >=3.5.
+Pull requests are welcome. Just make sure to test your code on both Python >=2.6 and >=3.5 for the main branch, and Python >= 3.6 for the development branch (In the next major release we'll drop support for older python versions in an effort to improve code readability).
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Restart Inkscape and you're done.
 
 More documentation coming soon. In the meantime you can refer to [JTP's official website](https://jtechphotonics.com/?page_id=2012).
 
+### Custom G-code Header and Footer
+
+Add "header" and "footer" text files without extensions in your destination directory to add custom commands. Don't forget to add a new line at the end of these two files.
+
+If no files are detected the default values are :
+- Header : G90 ; Absolute positioning
+- Footer : G1 X0 Y0 ; Move to X0 Y0
 
 ## For developers
 

--- a/laser.inx
+++ b/laser.inx
@@ -2,7 +2,7 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <_name>J Tech Photonics Laser Tool</_name>
     <id>jtechphotonics.com</id>
-	<dependency type="executable" location="extensions">laser.py</dependency>
+	<dependency type="executable" location="inx">laser.py</dependency>
 	<dependency type="executable" location="extensions">inkex.py</dependency>
 
 	<param name="laser-command" type="string" _gui-text="Laser ON Command:">M03</param>
@@ -30,7 +30,7 @@
   	</effect>
 
 	<script>
-		<command reldir="extensions" interpreter="python">laser.py</command>
+		<command reldir="inx" interpreter="python">laser.py</command>
 	</script>
 
 </inkscape-extension>

--- a/laser.py
+++ b/laser.py
@@ -31,7 +31,7 @@ from inkex.paths import Path
 
 import os
 import math
-import bezmisc
+
 import re
 import sys
 import time
@@ -57,6 +57,9 @@ if target_version < 1.0:
     # Inkex.Boolean
     inkex.Boolean = bool
 
+    import bezmisc as bezier
+
+
 else:
     # simplestyle
 
@@ -80,6 +83,9 @@ else:
     parsePath = CubicSuperPath
 
 
+    from inkex import bezier
+
+
 # Check if inkex has error messages. (0.46 version does not have one) Could be removed later.
 if "errormsg" not in dir(inkex):
     inkex.errormsg = lambda msg: sys.stderr.write((str(msg) + "\n").encode("UTF-8"))
@@ -87,7 +93,7 @@ if "errormsg" not in dir(inkex):
 
 def bezierslopeatt(xxx_todo_changeme, t):
     ((bx0, by0), (bx1, by1), (bx2, by2), (bx3, by3)) = xxx_todo_changeme
-    ax, ay, bx, by, cx, cy, x0, y0 = bezmisc.bezierparameterize(((bx0, by0), (bx1, by1), (bx2, by2), (bx3, by3)))
+    ax, ay, bx, by, cx, cy, x0, y0 = bezier.bezierparameterize(((bx0, by0), (bx1, by1), (bx2, by2), (bx3, by3)))
     dx = 3 * ax * (t ** 2) + 2 * bx * t + cx
     dy = 3 * ay * (t ** 2) + 2 * by * t + cy
     if dx == dy == 0:
@@ -105,7 +111,7 @@ def bezierslopeatt(xxx_todo_changeme, t):
     return dx, dy
 
 
-bezmisc.bezierslopeatt = bezierslopeatt
+bezier.bezierslopeatt = bezierslopeatt
 
 ################################################################################
 #
@@ -249,7 +255,7 @@ def csp_split(sp1, sp2, t=.5):
 
 
 def csp_curvature_at_t(sp1, sp2, t, depth=3):
-    ax, ay, bx, by, cx, cy, dx, dy = bezmisc.bezierparameterize(csp_segment_to_bez(sp1, sp2))
+    ax, ay, bx, by, cx, cy, dx, dy = bezier.bezierparameterize(csp_segment_to_bez(sp1, sp2))
 
     # curvature = (x'y''-y'x'') / (x'^2+y'^2)^1.5
 
@@ -293,7 +299,7 @@ def csp_at_t(sp1, sp2, t):
 
 def cspseglength(sp1, sp2, tolerance=0.001):
     bez = (sp1[1][:], sp1[2][:], sp2[0][:], sp2[1][:])
-    return bezmisc.bezierlength(bez, tolerance)
+    return bezier.bezierlength(bez, tolerance)
 
 
 #        Distance calculation from point to arc

--- a/laser.py
+++ b/laser.py
@@ -1357,7 +1357,7 @@ class LaserGcode(inkex.Effect):
             translate = [0, 0]
 
         # doc height in pixels (38 mm == 143.62204724px)
-        doc_height = self.unittouu(self.document.getroot().xpath('@height', namespaces=inkex.NSS)[0])
+        doc_height = self.svg.unittouu(self.document.getroot().xpath('@height', namespaces=inkex.NSS)[0])
 
         if self.document.getroot().get('height') == "100%":
             doc_height = 1052.3622047

--- a/laser.py
+++ b/laser.py
@@ -26,7 +26,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 import inkex
-import simpletransform
+from inkex.transforms import Transform
+from inkex.paths import Path
 
 import os
 import math
@@ -925,8 +926,8 @@ class LaserGcode(inkex.Effect):
         while (g != root):
             if 'transform' in list(g.keys()):
                 t = g.get('transform')
-                t = simpletransform.parseTransform(t)
-                trans = simpletransform.composeTransform(t, trans) if trans != [] else t
+                t = [list(row) for row in Transform(t).matrix] 
+                trans = [list(row) for row in (Transform(t) * Transform(trans)).matrix] if trans != [] else t
                 print_(trans)
             g = g.getparent()
         return trans
@@ -935,7 +936,7 @@ class LaserGcode(inkex.Effect):
     def apply_transforms(self, g, csp):
         trans = self.get_transforms(g)
         if trans != []:
-            simpletransform.applyTransformToPath(trans, csp)
+            csp = Path(csp).transform(Transform(trans)).to_superpath()
         return csp
 
 


### PR DESCRIPTION
Hi,
In 2018 I made addition to one of forks of your code (Gerbil) to sort paths based on path hierarchy. It worked on python 2 and Inkscape version before 1.0.
Here is the same sort adapted to python3 and newer Inkscape versions.
How it works:
Paths are sorted by containing other paths and first are cut paths which does not contain other paths (holes), next their containers, etc. This way the parts are cut outside after all contained paths (holes) are done and even if part fall after cut it is completely done with all holes in it.
I'm not python programmer, so my code is not very good, but it works in cases I tested. I'll be very happy if someone can make it better.
Best regards