### PR TITLE
Added folder picker for output directory

### DIFF
--- a/laser/laser.inx
+++ b/laser/laser.inx
@@ -15,7 +15,7 @@
 			<param name="cutting_speed" type="float" min="0" max="999999" _gui-text="Cutting Speed (unit/min):">750</param>
 			<param name="passes" type="int" min="1" max="100" _gui-text="Passes:">1</param>
 			<param name="pass_depth" type="float" min="0" max="10" _gui-text="Pass Depth (unit):">1</param>
-			<param name="directory" type="string" _gui-text="Output Directory:"></param>
+			<param name="directory" type="path" _gui-text="Output Directory:" mode="folder">-- Choose Output Directory --</param>
 			<param name="filename" type="string" _gui-text="Filename:">output.gcode</param>
 		</page>
 		<page name="advanced_settings" gui-text="Advanced Settings">


### PR DESCRIPTION
Changed type of output directory text field from "string" to "path (mode folder)".

Also, added a default value for the output directory, which forces an error when left unchanged. If text field is empty, the GCode file will be placed in the extension directory, which is not the first place I would be looking for it.

The proper behaviour would be to notify the user in a more readable way than just dumping the exception, but I don't know how to do that.