### PR TITLE
remove unnessessary whitespace in header/footer

### DIFF
--- a/laser/laser.py
+++ b/laser/laser.py
@@ -64,12 +64,12 @@ class GcodeExtension(EffectExtension):
         header = None
         if self.options.header_path:
             with open(self.options.header_path, 'r') as header_file:
-                header = header_file.readlines()
+                header = header_file.read().splitlines()
 
         footer = None
         if self.options.footer_path:
             with open(self.options.footer_path, 'r') as footer_file:
-                footer = footer_file.readlines()
+                footer = footer_file.read().splitlines()
 
         # Generate gcode
         self.clear_debug()


### PR DESCRIPTION
The readlines method includes the newline and other whitespace from the header/footer files. The compiler then adds another newline between every Gcode command. This leads to doubled newlines. This commit fixes this.