### PR TITLE
Added for negative horizontal-, vertical offsett and scale

### DIFF
--- a/laser/laser.inx
+++ b/laser/laser.inx
@@ -62,9 +62,9 @@
 			<param name="bed_width" type="float" min="0" max="999999" _gui-text="Bed X Width (unit)">200</param>
 			<param name="bed_height" type="float" min="0" max="999999" _gui-text="Bed Y Length (unit)">200</param>
 			<spacer></spacer>
-			<param name="horizontal_offset" type="float" min="0" max="999999" _gui-text="Gcode X Offset (unit)">0</param>
-			<param name="vertical_offset" type="float" min="0" max="999999" _gui-text="Gcode Y Offset (unit)">0</param>
-			<param name="scaling_factor" type="float" min="0" max="999999" _gui-text="Gcode Scaling Factor">1</param>
+			<param name="horizontal_offset" type="float" min="-999999" max="999999" _gui-text="Gcode X Offset (unit)">0</param>
+			<param name="vertical_offset" type="float" min="-999999" max="999999" _gui-text="Gcode Y Offset (unit)">0</param>
+			<param name="scaling_factor" type="float" min="-999999" max="999999" _gui-text="Gcode Scaling Factor">1</param>
 		</page>
 	</param>
 


### PR DESCRIPTION
By setting the min value for horizontal_offset and vertical_offset, the offset can also be used in negative directions. This is usefull if you need an offset in the other direction. (For example because your toolhead/laser is on the left from the carriages head.) The negative gcode scaling factor allows for a decrease in size.