### PR TITLE
Return the submenu to its original position

### DIFF
--- a/laser/laser.inx
+++ b/laser/laser.inx
@@ -60,9 +60,7 @@
     <effect>
         <object-type>path</object-type>
         <effects-menu>
-            <submenu name="FabLab Chemnitz">
-                <submenu name="Import/Export/Transfer"/>
-            </submenu>
+            <submenu name="Generate Laser Gcode"/>
         </effects-menu>
     </effect>
     <script>


### PR DESCRIPTION
I'm confused by the change in the position of the menu since #51. Can you please put it back to the original position if possible?