### PR TITLE
Add checkbox to reuse SVG filename for output

### DIFF
--- a/laser/laser.inx
+++ b/laser/laser.inx
@@ -16,6 +16,7 @@
             <spacer/>
             <param name="directory" type="path" gui-text="Output Directory" mode="folder">-- Choose Output Directory --</param>
             <param name="filename" type="string" gui-text="Filename">output.gcode</param>
+            <param name="filename_dynamic" type="boolean" gui-text="Reuse SVG filename for output">false</param>
             <param name="filename_suffix" type="bool" gui-text="Add Numeric Suffix to Filename">true</param>
         </page>
         <page name="advanced_settings" gui-text="Advanced Settings">

--- a/laser/laser.py
+++ b/laser/laser.py
@@ -49,7 +49,14 @@ class GcodeExtension(EffectExtension):
         TOLERANCES["approximation"] = float(self.options.approximation_tolerance.replace(',', '.'))
 
         # Construct output path
-        output_path = os.path.join(self.options.directory, self.options.filename)
+        # Construct output path
+        if self.options.filename_dynamic and self.document_path():
+            filename, extension = self.document_path().split('.')
+            filename = filename.split('/')[-1] + '.gcode'
+            output_path = os.path.join(self.options.directory, filename)
+        else:
+            output_path = os.path.join(self.options.directory, self.options.filename)
+
         if self.options.filename_suffix:
             try:
                 filename, extension = output_path.split('.')


### PR DESCRIPTION
Fixes #61

As described in the issue, this PR adds a checkbox to allow for a dynamic filename.
When it is set, the filename of the SVG is used for the gcode file. If the file hasn't been saved yet (document_path is empty), it will fallback to the configured filename.