### PR TITLE
Add line return if semi column to prevent comment

### DIFF
--- a/laser/laser.py
+++ b/laser/laser.py
@@ -26,10 +26,20 @@ def generate_custom_interface(laser_off_command, laser_power_command):
             super().__init__()
 
         def laser_off(self):
-            return f"{laser_off_command}"
+            """ add line return if semicolumn
+            ex: M3 S3000;G4 P0.5;
+                will result:
+                M3 S3000;
+                G4 P0.5;
+            """
+            command = f"{laser_off_command}"
+            command = command.replace(';', ';\n')
+            return f"{command}"
 
         def set_laser_power(self, _):
-            return f"{laser_power_command}"
+            command = f"{laser_power_command}"
+            command = command.replace(';', ';\n')
+            return f"{command}"
 
     return CustomInterface
 


### PR DESCRIPTION
Hello,

a small patch to add a line return (\n) if Tool command contains a semi column.

So that we can specify a delay:

`M3 S3000;G4 P0.5;`

G4 P0.5 will not be commented in Gcode

```
G1 F6000.0 X-107.666667 Y83.250000;
M3 S3000;
G4 P0.5;
```

![Capture d’écran de 2023-02-11 14-22-14](https://user-images.githubusercontent.com/6953974/218260345-bb64ecb1-d0d5-4846-93b2-dd5be0205fa1.png)
