### PR TITLE
feat: Allow multi-line power on and power off command.

### DIFF
--- a/laser/laser.py
+++ b/laser/laser.py
@@ -26,10 +26,10 @@ def generate_custom_interface(laser_off_command, laser_power_command):
             super().__init__()
 
         def laser_off(self):
-            return f"{laser_off_command}"
+            return laser_off_command.replace(r'\n', '\n')
 
         def set_laser_power(self, _):
-            return f"{laser_power_command}"
+            return laser_power_command.replace(r'\n', '\n')
 
     return CustomInterface
 


### PR DESCRIPTION
Some devices benefit from being able to being able to use multiple commands. For example pen plotters need a dwell after off to allow the pen to move out of the way. Lines are split with a '\n'.