### PR TITLE
Add options for grbl and for prepending dwell time

### DIFF
--- a/laser/laser.inx
+++ b/laser/laser.inx
@@ -22,6 +22,8 @@
             <param name="tool_power_command" type="string" gui-text="Tool Power Command">M3 S255;</param>
             <param name="tool_off_command" type="string" gui-text="Tool Off Command">M5;</param>
             <param name="dwell_time" type="float" gui-text="Dwell Time Before Moving (ms)">0</param>
+            <param name="dwell_time_for_grbl" gui-text="Adjust Dwell Time for grbl (s vs ms)" type="bool">true</param>
+            <param name="dwell_before_cut" gui-text="Apply Dwell Time before cut (not after)" type="bool">true</param>
             <spacer/>
             <param name="draw_debug" type="bool" gui-text="Draw Debug">true</param>
             <param name="debug_line_width" type="float" gui-text="Debug Line Width (px)">0.5</param>

--- a/laser/laser.py
+++ b/laser/laser.py
@@ -110,9 +110,12 @@ class GcodeExtension(EffectExtension):
             footer.append(interface_instance.linear_move(x=0, y=0))
 
         # Generate gcode
+        corrected_dwell_time = self.options.dwell_time
+        if self.options.dwell_time_for_grbl:
+            corrected_dwell_time = self.options.dwell_time/1000
         gcode_compiler = Compiler(custom_interface, self.options.travel_speed, self.options.cutting_speed,
-                                  self.options.pass_depth, dwell_time=self.options.dwell_time, custom_header=header,
-                                  custom_footer=footer, unit=self.options.unit)
+                                  self.options.pass_depth, dwell_time=corrected_dwell_time, custom_header=header,
+                                  custom_footer=footer, unit=self.options.unit, dwell_before_cut=self.options.dwell_before_cut)
 
         transformation = Transformation()
 


### PR DESCRIPTION
I've come across two issues with dwell time:

1. grbl interprets the G4 PX and X seconds (not milliseconds). I've added an option for this, which , when set, passes float(X/1000) to G4 P. It worked with my grbl version (1.1h).
2. I'm lasering, so my use case works best, when the dwell time is spent before cut motion starts (e.g. when cutting paper, the laser needs that bit more time to start cutting. Otherwise it will only do so, when accidentially hitting a black spot on the paper.
This 2nd point needs this PR to be merged in the upstream svg2gcode library: https://github.com/PadLex/SvgToGcode/pull/29 though.
